### PR TITLE
display human readable timestamp on results list page

### DIFF
--- a/lab_assistant/contrib/django/templates/lab_assistant/result_overview.html
+++ b/lab_assistant/contrib/django/templates/lab_assistant/result_overview.html
@@ -1,5 +1,5 @@
 <div class='result-overview expand' data-result-id='{{ result.id }}'>
-    <a href="{% url 'specific_mismatch' result.id %}">{{ result.id }}</a>
+    <a href="{% url 'specific_mismatch' result.id %}">{{ result.id }} {{ result.timestamp }}</a>
 
     {% include 'lab_assistant/observation.html' with observation=result.control control=True %}
 

--- a/lab_assistant/contrib/django/views.py
+++ b/lab_assistant/contrib/django/views.py
@@ -1,6 +1,8 @@
+from datetime import datetime
 from django.contrib.admin.views.decorators import staff_member_required
 from django.shortcuts import render
 from django.http import HttpResponse
+from simpleflake import parse_simpleflake
 
 from lab_assistant.storage import get_storage
 
@@ -13,6 +15,9 @@ def mismatch_list(request):
 
     storage = get_storage(name=name)
     results = storage.list()
+    for result in results:
+        result.timestamp = datetime.fromtimestamp(parse_simpleflake(result.key).timestamp).isoformat()
+
     return render(request, 'lab_assistant/result_list.html', {
         'results': results,
     })


### PR DESCRIPTION
Added this in the view (output), possibly better [here](https://github.com/joealcorn/lab_assistant/blob/django/lab_assistant/storage/__init__.py#L40) (input) but then existing data won't have the value set.